### PR TITLE
add diagnostics and Werror to CI build flags

### DIFF
--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -6,7 +6,7 @@ source $ILCSOFT/init_ilcsoft.sh
 cd /Package
 mkdir build
 cd build
-cmake -GNinja -C $ILCSOFT/ILCSoft.cmake -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" .. && \
+cmake -GNinja -C $ILCSOFT/ILCSoft.cmake -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" .. && \
 ninja && \
 ninja install && \
 ctest --output-on-failure


### PR DESCRIPTION

BEGINRELEASENOTES
- Update CI to not allow new warnings to be merged into MarlinFastJet

ENDRELEASENOTES