### PR TITLE
Adding substructure variables

### DIFF
--- a/include/FastJetTopTagger.h
+++ b/include/FastJetTopTagger.h
@@ -12,42 +12,24 @@
 #define FASTJETTOPTAGGER_H_
 
 #include <marlin/Processor.h>
-#include <marlin/VerbosityLevels.h>
 #include <EVENT/LCCollection.h>
 #include <IMPL/LCCollectionVec.h>
 #include <EVENT/ReconstructedParticle.h>
-#include "IMPL/LCCollectionVec.h"
 #include <IMPL/ReconstructedParticleImpl.h>
-#include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCGenericObjectImpl.h>
-#include <EVENT/MCParticle.h>
-
-#include <LCIOSTLTypes.h>
 
 #include <fastjet/PseudoJet.hh>
-#include "fastjet/SharedPtr.hh"
-#include <fastjet/JetDefinition.hh>
+#include <fastjet/SharedPtr.hh>
+#include <fastjet/Selector.hh>
 #include <fastjet/tools/JHTopTagger.hh>
-#include "fastjet/contrib/Njettiness.hh"
-#include "fastjet/contrib/EnergyCorrelator.hh"
-
-#include <iomanip>
-#include <stdlib.h>
-#include <stdio.h>
-#include <time.h>
-#include <iostream>
-#include <istream>
-#include <fstream>
-#include <sstream>
-#include <string>
-
-using namespace fastjet;
-using namespace fastjet::contrib;
+#include <fastjet/contrib/Njettiness.hh>
+#include <fastjet/contrib/Nsubjettiness.hh>
+#include <fastjet/contrib/EnergyCorrelator.hh>
 
 //Forward declarations
 class FastJetUtil;
 
-typedef std::vector<PseudoJet> PseudoJetList;
+typedef std::vector<fastjet::PseudoJet> PseudoJetList;
 
 class FastJetTopTagger : marlin::Processor {  
  public:
@@ -86,6 +68,7 @@ class FastJetTopTagger : marlin::Processor {
   std::string _lcParticleOutName;
   std::string _lcJetOutName;
   std::string _lcTopTaggerOutName;
+  std::string _lcSubStructureOutName;
 
   int _statsFoundJets;
   int _statsNrEvents;
@@ -96,6 +79,7 @@ class FastJetTopTagger : marlin::Processor {
 
   FastJetUtil* _fju;
 
+  bool _doSubstructure;
   double _beta;
   std::string _energyCorrelator;
   std::string _axesMode;
@@ -105,27 +89,27 @@ class FastJetTopTagger : marlin::Processor {
   double _deltaR;
   double _cos_theta_W_max;
 
-  JHTopTagger _jhtoptagger;
+  fastjet::JHTopTagger _jhtoptagger;
 
   FastJetTopTagger(const FastJetTopTagger& rhs) = delete;
   FastJetTopTagger & operator = (const FastJetTopTagger&) = delete;
   
-  double getECF(PseudoJet& jet, int whichECF, double beta, std::string energyCorrelator);
+  double getECF(fastjet::PseudoJet& jet, int whichECF, const std::string& energyCorr);
 
-  // Simple class to store Axes along with a name for display
+  // Simple class to store Axes along with a name
   class AxesStruct {
   private:
     // Shared Ptr so it handles memory management
-    SharedPtr<AxesDefinition> _axes_def;
+    fastjet::SharedPtr<fastjet::contrib::AxesDefinition> _axes_def;
   public:
-  AxesStruct(const AxesDefinition & axes_def)
+  AxesStruct(const fastjet::contrib::AxesDefinition & axes_def)
     : _axes_def(axes_def.create()) {}
     
     // Need special copy constructor to make it possible to put in a std::vector
   AxesStruct(const AxesStruct& myStruct)
     : _axes_def(myStruct._axes_def->create()) {}
     
-    const AxesDefinition & def() const {return *_axes_def;}
+    const fastjet::contrib::AxesDefinition & def() const {return *_axes_def;}
     std::string description() const {return _axes_def->description();}
     std::string short_description() const {return _axes_def->short_description();}
   };
@@ -134,26 +118,29 @@ class FastJetTopTagger : marlin::Processor {
   class MeasureStruct { 
   private:
     // Shared Ptr so it handles memory management
-    SharedPtr<MeasureDefinition> _measure_def;
+    fastjet::SharedPtr<fastjet::contrib::MeasureDefinition> _measure_def;
   public:
-  MeasureStruct(const MeasureDefinition& measure_def)
+  MeasureStruct(const fastjet::contrib::MeasureDefinition& measure_def)
     : _measure_def(measure_def.create()) {}
     
     // Need special copy constructor to make it possible to put in a std::vector
-  MeasureStruct(const MeasureStruct& myStruct)
+    MeasureStruct(const MeasureStruct& myStruct)
     : _measure_def(myStruct._measure_def->create()) {}
     
-    const MeasureDefinition & def() const {return *_measure_def;}
+    const fastjet::contrib::MeasureDefinition & def() const {return *_measure_def;}
     std::string description() const {return _measure_def->description();}  
   };
 
-  std::map<std::string, EnergyCorrelator::Measure> _energyCorrMap;
+  std::map<std::string, fastjet::contrib::EnergyCorrelator::Measure> _energyCorrMeasureMap;
+  int _maxECF;
+  std::map<std::string, std::vector<fastjet::contrib::EnergyCorrelator> > _energyCorrMap;
   std::map<std::string, AxesStruct > _axesModeMap;
   std::map<std::string, MeasureStruct > _measureModeMap;
+  std::map<int, fastjet::contrib::Nsubjettiness> _nsubjettinessMap;
     
 };
 
-std::ostream& operator<<(std::ostream&, const PseudoJet&);
+std::ostream& operator<<(std::ostream&, const fastjet::PseudoJet&);
 
 #endif /* FASTJETTOPTAGGER_H_ */
 

--- a/include/FastJetTopTagger.h
+++ b/include/FastJetTopTagger.h
@@ -80,7 +80,6 @@ class FastJetTopTagger : marlin::Processor {
   FastJetUtil* _fju;
 
   bool _doSubstructure;
-  double _beta;
   std::string _energyCorrelator;
   std::string _axesMode;
   std::string _measureMode;

--- a/include/FastJetTopTagger.h
+++ b/include/FastJetTopTagger.h
@@ -17,15 +17,37 @@
 #include <IMPL/LCCollectionVec.h>
 #include <EVENT/ReconstructedParticle.h>
 #include "IMPL/LCCollectionVec.h"
+#include <IMPL/ReconstructedParticleImpl.h>
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCGenericObjectImpl.h>
+#include <EVENT/MCParticle.h>
+
 #include <LCIOSTLTypes.h>
 
 #include <fastjet/PseudoJet.hh>
+#include "fastjet/SharedPtr.hh"
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/tools/JHTopTagger.hh>
+#include "fastjet/contrib/Njettiness.hh"
+#include "fastjet/contrib/EnergyCorrelator.hh"
 
-//Forward declaration
+#include <iomanip>
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+#include <iostream>
+#include <istream>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+using namespace fastjet;
+using namespace fastjet::contrib;
+
+//Forward declarations
 class FastJetUtil;
-typedef std::vector< fastjet::PseudoJet > PseudoJetList;
+
+typedef std::vector<PseudoJet> PseudoJetList;
 
 class FastJetTopTagger : marlin::Processor {  
  public:
@@ -74,20 +96,64 @@ class FastJetTopTagger : marlin::Processor {
 
   FastJetUtil* _fju;
 
-  std::string _R;
+  double _beta;
+  std::string _energyCorrelator;
+  std::string _axesMode;
+  std::string _measureMode;
+
   double _deltaP;
   double _deltaR;
   double _cos_theta_W_max;
 
-  // list of pseudo particles / jets
-  fastjet::JHTopTagger _jhtoptagger;
+  JHTopTagger _jhtoptagger;
 
- private:
   FastJetTopTagger(const FastJetTopTagger& rhs) = delete;
   FastJetTopTagger & operator = (const FastJetTopTagger&) = delete;
+  
+  double getECF(PseudoJet& jet, int whichECF, double beta, std::string energyCorrelator);
 
+  // Simple class to store Axes along with a name for display
+  class AxesStruct {
+  private:
+    // Shared Ptr so it handles memory management
+    SharedPtr<AxesDefinition> _axes_def;
+  public:
+  AxesStruct(const AxesDefinition & axes_def)
+    : _axes_def(axes_def.create()) {}
+    
+    // Need special copy constructor to make it possible to put in a std::vector
+  AxesStruct(const AxesStruct& myStruct)
+    : _axes_def(myStruct._axes_def->create()) {}
+    
+    const AxesDefinition & def() const {return *_axes_def;}
+    std::string description() const {return _axes_def->description();}
+    std::string short_description() const {return _axes_def->short_description();}
+  };
+  
+  // Simple class to store Measures to make it easier to put in std::vector
+  class MeasureStruct { 
+  private:
+    // Shared Ptr so it handles memory management
+    SharedPtr<MeasureDefinition> _measure_def;
+  public:
+  MeasureStruct(const MeasureDefinition& measure_def)
+    : _measure_def(measure_def.create()) {}
+    
+    // Need special copy constructor to make it possible to put in a std::vector
+  MeasureStruct(const MeasureStruct& myStruct)
+    : _measure_def(myStruct._measure_def->create()) {}
+    
+    const MeasureDefinition & def() const {return *_measure_def;}
+    std::string description() const {return _measure_def->description();}  
+  };
+
+  std::map<std::string, EnergyCorrelator::Measure> _energyCorrMap;
+  std::map<std::string, AxesStruct > _axesModeMap;
+  std::map<std::string, MeasureStruct > _measureModeMap;
+    
 };
 
-std::ostream& operator<<(std::ostream&, const fastjet::PseudoJet&);
+std::ostream& operator<<(std::ostream&, const PseudoJet&);
 
 #endif /* FASTJETTOPTAGGER_H_ */
+

--- a/include/VLCAxes.h
+++ b/include/VLCAxes.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <fastjet/contrib/AxesDefinition.hh>
+#include <fastjet/JetDefinition.hh>
+
+///------------------------------------------------------------------------
+/// \class VLC_Axes
+/// \brief Axes from exclusive VLC
+///
+/// Axes from VLC algorithm with E_scheme recombination.
+///------------------------------------------------------------------------
+class VLC_Axes : public fastjet::contrib::ExclusiveJetAxes {
+public:
+   /// Constructor
+  VLC_Axes(fastjet::JetDefinition* jet_def)
+    : fastjet::contrib::ExclusiveJetAxes(*jet_def)
+  {
+    //_plugin(plugin){
+    
+    setNPass(NO_REFINING);
+   }
+
+   /// Short description
+   virtual std::string short_description() const {
+      return "VLC";
+   };
+   
+   /// Long description
+   virtual std::string description() const {
+      std::stringstream stream;
+      stream << std::fixed << std::setprecision(2)
+      << "VLC Axes";
+      return stream.str();
+   };
+   
+   /// For copying purposes
+   virtual VLC_Axes* create() const {return new VLC_Axes(*this);}
+
+  // ~VLC_Axes(){
+  //   delete _plugin;
+  // }
+
+// private:
+//   Plugin* _plugin;
+
+};
+

--- a/src/FastJetTopTagger.cpp
+++ b/src/FastJetTopTagger.cpp
@@ -1,31 +1,25 @@
 /*
  * FastJetTopTagger.cpp
  *
- *  Created on: 26.09.2016
- *      Author: Rickard Stroem (CERN) - lars.rickard.stroem@cern.ch
- *          Marlin implementation of the JHTagger from FastJet
- *          incl. support for all jet algortihms, etc. implemented in fastjet 
- *          through new fastjet util header file
+ *  Created on: 26.09.2016 by Rickard Stroem (RS) (CERN) - lars.rickard.stroem@cern.ch
+ *  Modified on 04.05.2018 by RS - adding substructure variables
+ *      Marlin implementation of the JHTagger from FastJet
+ *      incl. support for all jet algortihms, etc. implemented in fastjet 
+ *      through new fastjet util header file
  */
 
 #include <FastJetTopTagger.h>
 #include <FastJetUtil.h>
 
-#include <IMPL/ReconstructedParticleImpl.h>
-#include <IMPL/LCCollectionVec.h>
-#include <IMPL/LCGenericObjectImpl.h>
-#include <EVENT/ReconstructedParticle.h>
-#include <EVENT/MCParticle.h>
-
 #include <fastjet/Selector.hh>
-#include <fastjet/tools/JHTopTagger.hh>
-
-#include <sstream>
-#include <iomanip>
+#include "fastjet/contrib/Nsubjettiness.hh"
 
 FastJetTopTagger aFastJetTopTagger;
 
 using namespace EVENT;
+using namespace IMPL;
+using namespace fastjet;
+using namespace fastjet::contrib;
 
 FastJetTopTagger::FastJetTopTagger() : Processor("FastJetTopTagger"),
 				       _lcParticleInName(""),
@@ -39,11 +33,18 @@ FastJetTopTagger::FastJetTopTagger() : Processor("FastJetTopTagger"),
 				       _statsNrSkippedMaxIterations(0),
 				       _storeParticlesInJets( false ),
 				       _fju(new FastJetUtil()),
-				       _R(""),
+				       _beta(0.),
+				       _energyCorrelator(""),
+				       _axesMode(""),
+				       _measureMode(""),
 				       _deltaP(0.),
 				       _deltaR(0.),
 				       _cos_theta_W_max(0.),
-				       _jhtoptagger(fastjet::JHTopTagger())
+				       _jhtoptagger(JHTopTagger()),
+				       _energyCorrMap(),
+				       _axesModeMap(),
+				       _measureModeMap()
+
 {
   _description = "Using the FastJet tool JHTagger to identify top jets";
   
@@ -59,7 +60,7 @@ FastJetTopTagger::FastJetTopTagger() : Processor("FastJetTopTagger"),
 			   _lcParticleOutName, "");
   registerOutputCollection(LCIO::RECONSTRUCTEDPARTICLE, "topTaggerOut", 
 			   "The top tagger output for each jet", _lcTopTaggerOutName, "TopTaggerOut");
-
+  
   registerProcessorParameter("storeParticlesInJets",
 			     "Store the list of particles that were clustered into jets in the recParticleOut collection",
 			     _storeParticlesInJets,
@@ -67,7 +68,25 @@ FastJetTopTagger::FastJetTopTagger() : Processor("FastJetTopTagger"),
   
   //Fastjet parameters
   _fju->registerFastJetParameters( this );
-
+  
+  //Substructure parameters
+  registerProcessorParameter("beta",
+			     "Beta is called angular exponent and weights the angular distances between the jet constituents compated to their pt in the calculation of the energy correlation function and subjettiness.",
+			     _beta,
+			     1.);
+  registerProcessorParameter("energyCorrelator",
+			     "Options for contrib::EnergyCorrelator: pt_R (transverse momenta and boost-invariant angles), E_theta (energy and angle as dot product of vectors), E_inv (energy and angle as (2p_i*p_j/E_i E_j) (default: E_theta).",
+			     _energyCorrelator,
+			     std::string("E_theta"));
+  registerProcessorParameter("axesMode",
+			     "Option for NSubjettiness calculation. See fastjet NSubjettiness module for all options.",
+			     _axesMode,
+			     std::string("OnePass_WTA_KT_Axes"));
+  registerProcessorParameter("measureMode",
+			     "Option for NSubjettiness calculation. See fastjet NSubjettiness module for all options. Normalised measure recommended only for advanced users.",
+			     _measureMode,
+			     std::string("UnnormalizedMeasure"));
+  
   //Top Tagger parameter
   registerProcessorParameter("deltaP",
 			     "Subjets must carry at least this fraction of the original jet's p_t",
@@ -100,11 +119,24 @@ void FastJetTopTagger::init()
   streamlog_out(MESSAGE) << "Jet Algorithm: " << _fju->_jetAlgo->description() << std::endl << std::endl;
   
   // initate the top tagger
-  _jhtoptagger = fastjet::JHTopTagger(_deltaP, _deltaR, _cos_theta_W_max); //mW=80.4
+  _jhtoptagger = JHTopTagger(_deltaP, _deltaR, _cos_theta_W_max); //mW=80.4
   streamlog_out(MESSAGE) << "Top tagger implementation: " << _jhtoptagger.description() << std::endl;
-  //_jhtoptagger.set_top_selector(fastjet::SelectorMassRange(145, 205));
-  //_jhtoptagger.set_W_selector(fastjet::SelectorMassRange(65, 95));
-  
+  //_jhtoptagger.set_top_selector(SelectorMassRange(145, 205)); //<--Not used here, can be set in analysis
+  //_jhtoptagger.set_W_selector(SelectorMassRange(65, 95)); //<--Not used here, can be set in analysis
+
+  // initate substructure variables
+  _energyCorrMap.insert(std::make_pair("pt_R", EnergyCorrelator::pt_R));
+  _energyCorrMap.insert(std::make_pair("E_theta", EnergyCorrelator::E_theta));
+  _energyCorrMap.insert(std::make_pair("E_inv", EnergyCorrelator::E_inv));
+
+  _axesModeMap.insert(std::make_pair("KT_Axes", KT_Axes()));
+  _axesModeMap.insert(std::make_pair("WTA_KT_Axes", WTA_KT_Axes()));
+  _axesModeMap.insert(std::make_pair("OnePass_KT_Axes", OnePass_KT_Axes()));
+  _axesModeMap.insert(std::make_pair("OnePass_WTA_KT_Axes", OnePass_WTA_KT_Axes()));
+
+  _measureModeMap.insert(std::make_pair("UnnormalizedMeasure", UnnormalizedMeasure(_beta)));
+
+  // counters
   _statsFoundJets = 0;
   _statsNrEvents = 0;
   _statsNrSkippedEmptyEvents = 0;
@@ -132,12 +164,12 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
     //create dummy empty collection only in case there are processor that need the presence of them in later stages
 
     //create output collection and save every jet with its particles in it 
-    IMPL::LCCollectionVec* lccJetsOut = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    LCCollectionVec* lccJetsOut = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
 
     //create output collection and save every particle which contributes to a jet
-    IMPL::LCCollectionVec* lccParticlesOut(NULL);
+    LCCollectionVec* lccParticlesOut(NULL);
     if (_storeParticlesInJets){
-      lccParticlesOut= new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+      lccParticlesOut= new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
       lccParticlesOut->setSubset(true);
     }
     
@@ -145,12 +177,12 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
     if (_storeParticlesInJets) evt->addCollection(lccParticlesOut, _lcParticleOutName);
 
     //create output collection for the top jets
-    IMPL::LCCollectionVec* lccTopTaggerOut = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-    IMPL::LCCollectionVec* lccTopTaggerWOut = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-    IMPL::LCCollectionVec* lccTopTaggerW1Out = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-    IMPL::LCCollectionVec* lccTopTaggerW2Out = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-    IMPL::LCCollectionVec* lccTopTaggernonWOut = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-    IMPL::LCCollectionVec* lccTopTaggerCosThetaW = new IMPL::LCCollectionVec(LCIO::LCGENERICOBJECT);
+    LCCollectionVec* lccTopTaggerOut = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    LCCollectionVec* lccTopTaggerWOut = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    LCCollectionVec* lccTopTaggerW1Out = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    LCCollectionVec* lccTopTaggerW2Out = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    LCCollectionVec* lccTopTaggernonWOut = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    LCCollectionVec* lccTopTaggerCosThetaW = new LCCollectionVec(LCIO::LCGENERICOBJECT);
     
     evt->addCollection(lccTopTaggerOut, _lcTopTaggerOutName);
     evt->addCollection(lccTopTaggerWOut, _lcTopTaggerOutName+"_W");
@@ -182,29 +214,45 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
   const unsigned nrJets = jets.size();
   
   // create output collection and save every jet with its particles in it
-  IMPL::LCCollectionVec* lccJetsOut = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+  LCCollectionVec* lccJetsOut = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
   
   // create output collection and save every particle which contributes to a jet
-  IMPL::LCCollectionVec* lccParticlesOut(NULL);
+  LCCollectionVec* lccParticlesOut(NULL);
   if (_storeParticlesInJets){
-    lccParticlesOut= new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    lccParticlesOut= new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
     lccParticlesOut->setSubset(true);
   }
 
   //Save TopTagger info of the jets into the lcio stream
-  IMPL::LCCollectionVec* lccTopTaggerOut = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-  IMPL::LCCollectionVec* lccTopTaggerWOut = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-  IMPL::LCCollectionVec* lccTopTaggerW1Out = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-  IMPL::LCCollectionVec* lccTopTaggerW2Out = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-  IMPL::LCCollectionVec* lccTopTaggernonWOut = new IMPL::LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+  LCCollectionVec* lccTopTaggerOut = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+  LCCollectionVec* lccTopTaggerWOut = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+  LCCollectionVec* lccTopTaggerW1Out = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+  LCCollectionVec* lccTopTaggerW2Out = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+  LCCollectionVec* lccTopTaggernonWOut = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
   
   //Save helicity information
-  IMPL::LCCollectionVec* lccTopTaggerCosThetaW = new IMPL::LCCollectionVec(LCIO::LCGENERICOBJECT);
-  IMPL::LCGenericObjectImpl* lcgTopTaggerCosThetaW = new IMPL::LCGenericObjectImpl(0, 0, 2);
+  LCCollectionVec* lccTopTaggerCosThetaW = new LCCollectionVec(LCIO::LCGENERICOBJECT);
+  LCGenericObjectImpl* lcgTopTaggerCosThetaW = new LCGenericObjectImpl(0, 0, 2);
   
-  int nTops = 0;  
+  //Defining substructure functions
+  Nsubjettiness nSubJettiness1(1, (_axesModeMap.find(_axesMode)->second).def(), (_measureModeMap.find(_measureMode)->second).def());
+  Nsubjettiness nSubJettiness2(2, (_axesModeMap.find(_axesMode)->second).def(), (_measureModeMap.find(_measureMode)->second).def());
+  Nsubjettiness nSubJettiness3(3, (_axesModeMap.find(_axesMode)->second).def(), (_measureModeMap.find(_measureMode)->second).def());
+  
+  //Save substructure functions
+  LCCollectionVec* lccSubStructure = new LCCollectionVec(LCIO::LCGENERICOBJECT);
+  LCGenericObjectImpl* lcgSubStructureC2 = new LCGenericObjectImpl(0, 0, 2);
+  LCGenericObjectImpl* lcgSubStructureD2 = new LCGenericObjectImpl(0, 0, 2);
+  LCGenericObjectImpl* lcgSubStructureC3 = new LCGenericObjectImpl(0, 0, 2);
+  LCGenericObjectImpl* lcgSubStructureD3 = new LCGenericObjectImpl(0, 0, 2);
+  LCGenericObjectImpl* lcgSubStructureTau1 = new LCGenericObjectImpl(0, 0, 2);
+  LCGenericObjectImpl* lcgSubStructureTau2 = new LCGenericObjectImpl(0, 0, 2);
+  LCGenericObjectImpl* lcgSubStructureTau3 = new LCGenericObjectImpl(0, 0, 2);
+  
+  //Loop over jets
+  int index = 0;  
   PseudoJetList::iterator it;
-  for(it=jets.begin(); it != jets.end(); it++, nTops++) {
+  for(it=jets.begin(); it != jets.end(); it++, index++) {
     
     // create a reconstructed particle for this jet, and add all the containing particles to it
     ReconstructedParticle* rec = _fju->convertFromPseudoJet((*it), _fju->_cs->constituents(*it), particleIn);
@@ -216,9 +264,28 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
         lccParticlesOut->addElement(p); 
       }
     }
+
+    //Save substructure information
+
+    //Substructure - energy correlation 
+    double ECF1 = getECF(*it, 1, _beta, _energyCorrelator);
+    double ECF2 = getECF(*it, 2, _beta, _energyCorrelator);   
+    double ECF3 = getECF(*it, 3, _beta, _energyCorrelator);   
+    double ECF4 = getECF(*it, 4, _beta, _energyCorrelator);   
+    double C2 = ECF3*pow(ECF1,1)/pow(ECF2, 2); lcgSubStructureC2->setDoubleVal(index, C2); 
+    double D2 = ECF3*pow(ECF1,3)/pow(ECF2, 3); lcgSubStructureD2->setDoubleVal(index, D2);
+    double C3 = ECF4*pow(ECF2,1)/pow(ECF3, 2); lcgSubStructureC3->setDoubleVal(index, C3);
+    double D3 = ECF4*pow(ECF2,3)/pow(ECF3, 3); lcgSubStructureD3->setDoubleVal(index, D3);
+    
+    //Substructure - NSubjettiness
+    double tau1 = nSubJettiness1(*it); lcgSubStructureTau1->setDoubleVal(index, tau1);
+    double tau2 = nSubJettiness2(*it); lcgSubStructureTau2->setDoubleVal(index, tau2);
+    double tau3 = nSubJettiness3(*it); lcgSubStructureTau3->setDoubleVal(index, tau3);
+
+    //John-Hopkins top tagger
     
     // search for top quark like structure in jet
-    fastjet::PseudoJet top_candidate = _jhtoptagger(*it);
+    PseudoJet top_candidate = _jhtoptagger(*it);
     
     if (top_candidate == 0){ 
       
@@ -227,36 +294,36 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
       lccTopTaggernonWOut->addElement(new ReconstructedParticleImpl());
       lccTopTaggerW1Out->addElement(new ReconstructedParticleImpl());
       lccTopTaggerW2Out->addElement(new ReconstructedParticleImpl());
-      lcgTopTaggerCosThetaW->setDoubleVal(nTops, 0.);
+      lcgTopTaggerCosThetaW->setDoubleVal(index, 0.);
 
     } else {      
       // save top candidate
       ReconstructedParticle* t = _fju->convertFromPseudoJet(top_candidate, top_candidate.constituents(), particleIn);	    
       lccTopTaggerOut->addElement(t);
-      
+
       // save W candidate
-      fastjet::PseudoJet top_candidate_W = top_candidate.structure_of<fastjet::JHTopTagger>().W();
+      PseudoJet top_candidate_W = top_candidate.structure_of<JHTopTagger>().W();
       ReconstructedParticle* W = _fju->convertFromPseudoJet(top_candidate_W, top_candidate_W.constituents(), particleIn);	    
       lccTopTaggerWOut->addElement(W);
       
       // save part 1 of W candidate
-      fastjet::PseudoJet top_candidate_W1 = top_candidate.structure_of<fastjet::JHTopTagger>().W1();
+      PseudoJet top_candidate_W1 = top_candidate.structure_of<JHTopTagger>().W1();
       ReconstructedParticle* W1 = _fju->convertFromPseudoJet(top_candidate_W1, top_candidate_W1.constituents(), particleIn);	    
       lccTopTaggerW1Out->addElement(W1);
       
       // save part 2 of W candidate
-      fastjet::PseudoJet top_candidate_W2 = top_candidate.structure_of<fastjet::JHTopTagger>().W2();
+      PseudoJet top_candidate_W2 = top_candidate.structure_of<JHTopTagger>().W2();
       ReconstructedParticle* W2 = _fju->convertFromPseudoJet(top_candidate_W2, top_candidate_W2.constituents(), particleIn);	    
       lccTopTaggerW2Out->addElement(W2);    
 
       // save non-W subjet of top candidate
-      fastjet::PseudoJet top_candidate_nonW = top_candidate.structure_of<fastjet::JHTopTagger>().non_W();
+      PseudoJet top_candidate_nonW = top_candidate.structure_of<JHTopTagger>().non_W();
       ReconstructedParticle* nonW = _fju->convertFromPseudoJet(top_candidate_nonW, top_candidate_nonW.constituents(), particleIn);	    
       lccTopTaggernonWOut->addElement(nonW);
          
       // save the polarisation angle of W
-      double top_candidate_cos_theta_W = top_candidate.structure_of<fastjet::JHTopTagger>().cos_theta_W();
-      lcgTopTaggerCosThetaW->setDoubleVal(nTops, top_candidate_cos_theta_W);
+      double top_candidate_cos_theta_W = top_candidate.structure_of<JHTopTagger>().cos_theta_W();
+      lcgTopTaggerCosThetaW->setDoubleVal(index, top_candidate_cos_theta_W);
 
     }
   }
@@ -264,6 +331,15 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
   evt->addCollection(lccJetsOut, _lcJetOutName);
   if (_storeParticlesInJets) evt->addCollection(lccParticlesOut, _lcParticleOutName);
   
+  lccSubStructure->addElement(lcgSubStructureC2);
+  lccSubStructure->addElement(lcgSubStructureD2);
+  lccSubStructure->addElement(lcgSubStructureC3);
+  lccSubStructure->addElement(lcgSubStructureD3);
+  lccSubStructure->addElement(lcgSubStructureTau1);
+  lccSubStructure->addElement(lcgSubStructureTau2);
+  lccSubStructure->addElement(lcgSubStructureTau3);
+  evt->addCollection(lccSubStructure, "TopTaggerSubStructure");
+
   evt->addCollection(lccTopTaggerOut, _lcTopTaggerOutName);
   evt->addCollection(lccTopTaggerWOut, _lcTopTaggerOutName+"_W");
   evt->addCollection(lccTopTaggernonWOut, _lcTopTaggerOutName+"_nonW");
@@ -286,6 +362,22 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
   
 } //end processEvent
 
+double FastJetTopTagger::getECF(PseudoJet& jet, int whichECF, double beta, std::string energyCorrelator){
+  /// ********** Energy Correlation Function *** /////////
+
+  // options for EnergyCorrelator:
+  //   pt_R (transverse momenta and boost-invariant angles)
+  //   E_theta (energy and angle as dot product of vectors)
+  //   E_inv (energy and angle as (2p_i \cdot p_j/E_i E_j)
+
+  if(!jet.has_constituents())
+    return -1.0;
+    
+  EnergyCorrelator ECF(whichECF, beta, _energyCorrMap[energyCorrelator]);
+
+  return ECF(jet);
+} //end
+
 void FastJetTopTagger::end()
 {
   streamlog_out(MESSAGE)
@@ -297,7 +389,7 @@ void FastJetTopTagger::end()
     << std::endl;
 } //end end
 
-std::ostream& operator<<(std::ostream& ostr, const fastjet::PseudoJet& jet){
+std::ostream& operator<<(std::ostream& ostr, const PseudoJet& jet){
   ostr << "pt, y, phi =" << std::setprecision(6)
        << " " << std::setw(9) << jet.perp()
        << " " << std::setw(9) << jet.rap()


### PR DESCRIPTION
BEGINRELEASENOTES
- Implemented substructure parameters commonly used for top tagging. The definition of these new variables can be adjusted from the steering file (added options to steer how to calculate the energy correlation function (energyCorrelator) and how to calculate NSubjettiness (axesMode and measureMode). Only recommended options are implemented. The beta parameter would typically be the same as used for jet clustering but can also be varied separately (beta weights the angular distances between the jet constituents compared to their pt in the calculation of the energy correlation function and subjettiness). 
- The substructure variables are added to the file as a collection "TopTaggerSubStructure" of seven elements (order: C2, D2, C3, D3, tau1, tau2, tau3). 
- This update is backwards compatible, with the only difference being the addition of this collection.

ENDRELEASENOTES