### PR TITLE
fix order of fastjet libraries for UB linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ INCLUDE_DIRECTORIES( SYSTEM ${ROOT_INCLUDE_DIRS} )
 LINK_LIBRARIES( ${ROOT_LIBRARIES} )
 ADD_DEFINITIONS( ${ROOT_DEFINITIONS} )
 
-FIND_PACKAGE(FastJet 3 REQUIRED COMPONENTS siscone siscone_spherical fastjetplugins fastjetcontribfragile fastjettools)
+FIND_PACKAGE(FastJet 3 REQUIRED COMPONENTS fastjetplugins fastjetcontribfragile fastjettools siscone_spherical siscone)
 
 INCLUDE_DIRECTORIES( SYSTEM ${FastJet_INCLUDE_DIRS} )
 LINK_LIBRARIES( ${FastJet_LIBRARIES} ${FastJet_COMPONENT_LIBRARIES} )


### PR DESCRIPTION

BEGINRELEASENOTES
- fix order of fastjet libraries at linking step - needed on Ubuntu systems
-  fixes https://github.com/iLCSoft/iLCInstall/issues/128

ENDRELEASENOTES