### PR TITLE
Fix mem leak in clusterJets

### DIFF
--- a/include/FastJetUtil.h
+++ b/include/FastJetUtil.h
@@ -49,7 +49,6 @@
 
 #include <stdexcept>
 #include <string>
-#include <tuple>
 
 #define ITERATIVE_INCLUSIVE_MAX_ITERATIONS 20
 typedef std::vector< fastjet::PseudoJet > PseudoJetList;
@@ -159,7 +158,7 @@ public:
   /// convert fastjet pseudojet to reconstructed particle
   inline EVENT::ReconstructedParticle* convertFromPseudoJet(const fastjet::PseudoJet& jet, const PseudoJetList& constituents, LCCollection* reconstructedPars);
   /// does the actual clustering
-  inline std::tuple<PseudoJetList, fastjet::ClusterSequence> clusterJets(PseudoJetList& pjList, LCCollection* reconstructedPars);
+  inline PseudoJetList clusterJets(PseudoJetList& pjList, fastjet::ClusterSequence& cs, LCCollection* reconstructedPars);
 
 protected:
   // helper functions to init the jet algorithms in general
@@ -483,11 +482,9 @@ void FastJetUtil::initClusterMode() {
 
 }
 
-std::tuple<PseudoJetList, fastjet::ClusterSequence>
-FastJetUtil::clusterJets( PseudoJetList& pjList, LCCollection* reconstructedPars) {
+PseudoJetList FastJetUtil::clusterJets(PseudoJetList& pjList, fastjet::ClusterSequence& cs, LCCollection* reconstructedPars) {
   ///////////////////////////////
   // do the jet finding for the user defined parameter jet finder
-  auto cs = fastjet::ClusterSequence(pjList, *_jetAlgo);
 
   PseudoJetList jets; // will contain the found jets
 
@@ -529,7 +526,7 @@ FastJetUtil::clusterJets( PseudoJetList& pjList, LCCollection* reconstructedPars
 
   }
 
-  return std::make_tuple<PseudoJetList, fastjet::ClusterSequence>(std::move(jets), std::move(cs));
+  return jets;
 
 }
 

--- a/include/FastJetUtil.h
+++ b/include/FastJetUtil.h
@@ -35,19 +35,21 @@
 #include <IMPL/ReconstructedParticleImpl.h>
 
 //FastJet
+#include <fastjet/CDFJetCluPlugin.hh>
+#include <fastjet/CDFMidPointPlugin.hh>
+#include <fastjet/ClusterSequence.hh>
+#include <fastjet/EECambridgePlugin.hh>
+#include <fastjet/JadePlugin.hh>
+#include <fastjet/NestedDefsPlugin.hh>
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/SISConePlugin.hh>
 #include <fastjet/SISConeSphericalPlugin.hh>
-#include <fastjet/CDFMidPointPlugin.hh>
-#include <fastjet/CDFJetCluPlugin.hh>
-#include <fastjet/NestedDefsPlugin.hh>
-#include <fastjet/EECambridgePlugin.hh>
-#include <fastjet/JadePlugin.hh>
 
 #include <fastjet/contrib/ValenciaPlugin.hh>
 
 #include <stdexcept>
 #include <string>
+#include <tuple>
 
 #define ITERATIVE_INCLUSIVE_MAX_ITERATIONS 20
 typedef std::vector< fastjet::PseudoJet > PseudoJetList;

--- a/include/FastJetUtil.h
+++ b/include/FastJetUtil.h
@@ -62,8 +62,8 @@ public:
 
 class SkippedMaxIterationException: public std::runtime_error {
 public:
-  SkippedMaxIterationException( PseudoJetList& jets) :std::runtime_error(""), _jets(jets) {}
-  PseudoJetList& _jets;
+  SkippedMaxIterationException(PseudoJetList& jets) :std::runtime_error(""), _jets(jets) {}
+  PseudoJetList _jets;
 };
 
 

--- a/src/FastJetProcessor.cpp
+++ b/src/FastJetProcessor.cpp
@@ -136,8 +136,9 @@ void FastJetProcessor::processEvent(LCEvent * evt)
   PseudoJetList pjList = _fju->convertFromRecParticle(particleIn);
 
   PseudoJetList jets;
+  fastjet::ClusterSequence cs;
   try {
-    jets = _fju->clusterJets(pjList, particleIn);
+    std::tie(jets, cs) = _fju->clusterJets(pjList, particleIn);
   } catch(const SkippedFixedNrJetException& e ) {
     _statsNrSkippedFixedNrJets++;
   } catch(const SkippedMaxIterationException& e ) {
@@ -163,13 +164,13 @@ void FastJetProcessor::processEvent(LCEvent * evt)
 
   for (it=jets.begin(); it != jets.end(); it++) {
     // create a reconstructed particle for this jet, and add all the containing particles to it
-    ReconstructedParticle* rec = _fju->convertFromPseudoJet( (*it), _fju->_cs->constituents(*it), particleIn);
+    ReconstructedParticle* rec = _fju->convertFromPseudoJet( (*it), cs.constituents(*it), particleIn);
     lccJetsOut->addElement( rec );
 
     if (_storeParticlesInJets) {
-      for (unsigned int n = 0; n < _fju->_cs->constituents(*it).size(); ++n) {
+      for (unsigned int n = 0; n < cs.constituents(*it).size(); ++n) {
 	ReconstructedParticle* p =
-	  static_cast<ReconstructedParticle*>(particleIn->getElementAt((_fju->_cs->constituents(*it))[n].user_index()));
+	  static_cast<ReconstructedParticle*>(particleIn->getElementAt((cs.constituents(*it))[n].user_index()));
 	lccParticlesOut->addElement( p );
       }
     }
@@ -183,10 +184,10 @@ void FastJetProcessor::processEvent(LCEvent * evt)
     // save the dcut value for this algorithm (although it might not be meaningful)
     LCParametersImpl &lccJetParams((LCParametersImpl &)lccJetsOut->parameters());
 
-    lccJetParams.setValue(std::string("d_{n-1,n}"), (float)_fju->_cs->exclusive_dmerge(nrJets-1));
-    lccJetParams.setValue(std::string("d_{n,n+1}"), (float)_fju->_cs->exclusive_dmerge(nrJets));
-    lccJetParams.setValue(std::string("y_{n-1,n}"), (float)_fju->_cs->exclusive_ymerge(nrJets-1));
-    lccJetParams.setValue(std::string("y_{n,n+1}"), (float)_fju->_cs->exclusive_ymerge(nrJets));
+    lccJetParams.setValue(std::string("d_{n-1,n}"), (float)cs.exclusive_dmerge(nrJets-1));
+    lccJetParams.setValue(std::string("d_{n,n+1}"), (float)cs.exclusive_dmerge(nrJets));
+    lccJetParams.setValue(std::string("y_{n-1,n}"), (float)cs.exclusive_ymerge(nrJets-1));
+    lccJetParams.setValue(std::string("y_{n,n+1}"), (float)cs.exclusive_ymerge(nrJets));
   }
 
 }

--- a/src/FastJetProcessor.cpp
+++ b/src/FastJetProcessor.cpp
@@ -136,9 +136,9 @@ void FastJetProcessor::processEvent(LCEvent * evt)
   PseudoJetList pjList = _fju->convertFromRecParticle(particleIn);
 
   PseudoJetList jets;
-  fastjet::ClusterSequence cs;
+  fastjet::ClusterSequence cs = fastjet::ClusterSequence(pjList, *_fju->_jetAlgo);
   try {
-    std::tie(jets, cs) = _fju->clusterJets(pjList, particleIn);
+    jets = _fju->clusterJets(pjList, cs, particleIn);
   } catch(const SkippedFixedNrJetException& e ) {
     _statsNrSkippedFixedNrJets++;
   } catch(const SkippedMaxIterationException& e ) {

--- a/src/FastJetTopTagger.cpp
+++ b/src/FastJetTopTagger.cpp
@@ -208,9 +208,11 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
   
   //Jet finding
   PseudoJetList jets;
+  fastjet::ClusterSequence cs;
   try {
     // sort jets according to pt
-    jets = sorted_by_pt(_fju->clusterJets(pjList, particleIn));
+    std::tie(jets, cs) = _fju->clusterJets(pjList, particleIn);
+    jets = sorted_by_pt(jets);
   } catch(SkippedFixedNrJetException& e){
     _statsNrSkippedFixedNrJets++; 
   } catch( SkippedMaxIterationException& e ) {
@@ -274,12 +276,12 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
   for(it=jets.begin(); it != jets.end(); it++, index++) {
     
     // create a reconstructed particle for this jet, and add all the containing particles to it
-    ReconstructedParticle* rec = _fju->convertFromPseudoJet((*it), _fju->_cs->constituents(*it), particleIn);
+    ReconstructedParticle* rec = _fju->convertFromPseudoJet((*it), cs.constituents(*it), particleIn);
     lccJetsOut->addElement( rec );
     
     if (_storeParticlesInJets) {
-      for (unsigned int n = 0; n < _fju->_cs->constituents(*it).size(); ++n){
-	ReconstructedParticle* p = static_cast<ReconstructedParticle*>(particleIn->getElementAt((_fju->_cs->constituents(*it))[n].user_index()));
+      for (unsigned int n = 0; n < cs.constituents(*it).size(); ++n){
+	ReconstructedParticle* p = static_cast<ReconstructedParticle*>(particleIn->getElementAt((cs.constituents(*it))[n].user_index()));
         lccParticlesOut->addElement(p); 
       }
     }
@@ -377,10 +379,10 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
     // save the dcut value for this algorithm (although it might not be meaningful)
     LCParametersImpl &lccJetParams((LCParametersImpl &)lccJetsOut->parameters());
     
-    lccJetParams.setValue(std::string("d_{n-1,n}"), (float)_fju->_cs->exclusive_dmerge(nrJets-1));
-    lccJetParams.setValue(std::string("d_{n,n+1}"), (float)_fju->_cs->exclusive_dmerge(nrJets));
-    lccJetParams.setValue(std::string("y_{n-1,n}"), (float)_fju->_cs->exclusive_ymerge(nrJets-1));
-    lccJetParams.setValue(std::string("y_{n,n+1}"), (float)_fju->_cs->exclusive_ymerge(nrJets));
+    lccJetParams.setValue(std::string("d_{n-1,n}"), (float)cs.exclusive_dmerge(nrJets-1));
+    lccJetParams.setValue(std::string("d_{n,n+1}"), (float)cs.exclusive_dmerge(nrJets));
+    lccJetParams.setValue(std::string("y_{n-1,n}"), (float)cs.exclusive_ymerge(nrJets-1));
+    lccJetParams.setValue(std::string("y_{n,n+1}"), (float)cs.exclusive_ymerge(nrJets));
   }
   
 } //end processEvent

--- a/src/FastJetTopTagger.cpp
+++ b/src/FastJetTopTagger.cpp
@@ -208,11 +208,10 @@ void FastJetTopTagger::processEvent(LCEvent * evt){
   
   //Jet finding
   PseudoJetList jets;
-  fastjet::ClusterSequence cs;
+  fastjet::ClusterSequence cs = fastjet::ClusterSequence(pjList, *_fju->_jetAlgo);
   try {
     // sort jets according to pt
-    std::tie(jets, cs) = _fju->clusterJets(pjList, particleIn);
-    jets = sorted_by_pt(jets);
+    jets = sorted_by_pt(_fju->clusterJets(pjList, cs, particleIn));
   } catch(SkippedFixedNrJetException& e){
     _statsNrSkippedFixedNrJets++; 
   } catch( SkippedMaxIterationException& e ) {


### PR DESCRIPTION
BEGINRELEASENOTES
- FastJetUtil: fix memory leak in clusterJets function. Change signature of this function to include the clusterSequence, fixes #20 
- FastJetProcessor: fix issue for kt algorithm ,fixes #15

ENDRELEASENOTES