### PR TITLE
Bump the minimum version of CMake to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################
 # cmake file for building Marlin example Package
 # @author Jan Engels, Desy IT
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)
 ########################################################
 
 # project name


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the minimum version of CMake to 3.10 to be able to compile with CMake 4

ENDRELEASENOTES

I tested that I can build fine on the stack.